### PR TITLE
feat: integrate hyper nano in setup

### DIFF
--- a/hyper-dev.js
+++ b/hyper-dev.js
@@ -1,0 +1,11 @@
+const { existsSync } = require("fs");
+const { execSync } = require("child_process");
+
+if (existsSync("./hyper-nano")) {
+  void execSync("./hyper-nano --domain='notes-dev' --experimental --data --cache", {
+    stdio: "inherit",
+    cwd: __dirname,
+  });
+} else {
+  console.log(`No hyper-nano found. Noop`);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "remix-hyper-stack",
       "license": "Apache-2.0",
       "dependencies": {
         "@architect/architect": "^10.2.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev:arc": "node ./arc-dev sandbox",
     "dev:css": "npm run generate:css -- --watch",
     "dev:remix": "remix watch",
+    "dev:hyper": "node ./hyper-dev",
     "format": "prettier --write .",
     "generate:css": "tailwindcss -o ./app/styles/tailwind.css",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",

--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -1,3 +1,4 @@
+const { execSync } = require("child_process");
 const crypto = require("crypto");
 const fs = require("fs/promises");
 const path = require("path");
@@ -62,18 +63,35 @@ async function main({ rootDirectory }) {
   await Promise.all([fs.writeFile(ENV_PATH, newEnv)]);
 }
 
-async function askSetupQuestions() {
+async function askSetupQuestions({ rootDirectory }) {
   let HYPER;
-  const answers = await inquirer.prompt([
+
+  const res = await inquirer.prompt([
     {
-      name: "connection",
-      type: "input",
-      message: "Please provide a hyper cloud application connection string",
-      default: "cloud://key:secret@cloud.hyper.io/app-name",
+      name: "nano",
+      type: "confirm",
+      message: "Would you like to use hyper nano ⚡️ for local development?",
+      default: true,
     },
   ]);
 
-  HYPER = answers.connection;
+  if (res.nano) {
+    execSync(`curl https://hyperland.s3.amazonaws.com/hyper -o hyper-nano && chmod +x hyper-nano`, {
+      stdio: "inherit",
+      cwd: rootDirectory,
+    });
+    HYPER = "http://localhost:6363/notes-dev";
+  } else {
+    const answers = await inquirer.prompt([
+      {
+        name: "connection",
+        type: "input",
+        message: "Please provide a hyper cloud application connection string",
+        default: "cloud://key:secret@cloud.hyper.io/app-name",
+      },
+    ]);
+    HYPER = answers.connection;
+  }
 
   console.log(`✅ Project is ready! Start development with "npm run dev"`);
 


### PR DESCRIPTION
As part of `remix.init` setup, the user can opt to use [`hyper nano`](https://github.com/hyper63/hyper/tree/main/images/nano) for local development.
