### PR TITLE
fix: ignore lockfiles in stack source, but do not when init #5

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,7 +4,7 @@ body:
   - type: markdown
     attributes:
       value: >-
-        Thank you for helping to improve the Hyper Remix Stack!
+        Thank you for helping to improve the Alternative Stack!
 
         Our bandwidth on maintaining these stacks is limited. As a team, we're
         currently focusing our efforts on Hyper and Hyper Cloud itself. The good news is you can

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: false
 
       - name: 🛠 Build
         run: npm run build
@@ -50,6 +52,8 @@ jobs:
 
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: false
 
       - name: 🔬 Lint
         run: npm run lint
@@ -71,6 +75,8 @@ jobs:
 
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: false
 
       - name: 🔎 Type check
         run: npm run typecheck --if-present
@@ -92,6 +98,8 @@ jobs:
 
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: false
 
       - name: ⚡ Run vitest
         run: npm run test -- --coverage
@@ -124,6 +132,8 @@ jobs:
 
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: false
 
       - name: 🏗 Build
         run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,16 @@
+#<rm>
+# We don't want lockfiles in stack templates,
+# as people could use a different package manager
+# This part will be removed by `remix.init`
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+pnpm-lock.yml
+#</rm>
 node_modules
 coverage
 
-/server/index.js
+/server
 /public/build
 preferences.arc
 sam.json

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,8 @@
       "~/*": ["./app/*"]
     },
     "skipLibCheck": true,
-
-    // Remix takes care of building everything in `remix build`.
-    "noEmit": true
+    "noEmit": true,
+    "allowJs": true,
+    "forceConsistentCasingInFileNames": true
   }
 }


### PR DESCRIPTION
Closes #5

This PR builds on #4 , in adding code to `remix.init` that will "un-ignore" the lockfile. This happens in 2 two places:

- .`gitignore`
- `deply.yml` workflow

This is because the stack itself is effectively a library, and doesn't need a lockfile. Additionally, we do not know which package manager the user will decide to use when initializing the stack.

Once the stack is initialized though, it "becomes" an application, and it should commit a lockfile, and then enforce as part of CI, as it is best practice. So by "un-ignoring" the lockfile on initilization, we encourage that best practice for applications.
