### PR TITLE
fix: use relative path for test route #9

### DIFF
--- a/app/services/note.server.ts
+++ b/app/services/note.server.ts
@@ -37,10 +37,17 @@ export const NotesServerFactory = (env: ServerContext): NoteServer => {
     }
 
     // TODO: use hyper cache to instead of querying db
-    const { docs } = await hyper.data.query<NoteDoc>({
+    const res = await hyper.data.query<NoteDoc>({
       type: "note",
       parent,
     });
+
+    if (!res.ok) {
+      throw new Error(res.msg);
+    }
+
+    const { docs } = res;
+
     return docs.map(fromHyper.as(NoteSchema));
   }
 

--- a/app/services/user.server.ts
+++ b/app/services/user.server.ts
@@ -30,7 +30,13 @@ export const UserServerFactory = (env: ServerContext): UserServer => {
     const { hyper } = env;
 
     email = EmailSchema.parse(email);
-    const { docs } = await hyper.data.query<UserDoc>({ type: "user", email });
+    const res = await hyper.data.query<UserDoc>({ type: "user", email });
+
+    if (!res.ok) {
+      throw new Error(res.msg);
+    }
+
+    const { docs } = res;
 
     if (!docs.length) {
       return null;
@@ -53,10 +59,16 @@ export const UserServerFactory = (env: ServerContext): UserServer => {
       throw new NotFoundError(`user with email ${email} not found`);
     }
 
-    const { docs } = await hyper.data.query<PasswordDoc>({
+    const res = await hyper.data.query<PasswordDoc>({
       type: "password",
       parent: user.id,
     });
+
+    if (!res.ok) {
+      throw new Error(res.msg);
+    }
+
+    const { docs } = res;
 
     if (!docs.length) {
       // TODO: use hyper queue to create job to send alert

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",
     "@vitejs/plugin-react": "^1.3.2",
+    "@vitest/coverage-c8": "^0.23.2",
     "c8": "^7.11.3",
     "cross-env": "^7.0.3",
     "cypress": "^9.7.0",
@@ -66,8 +67,8 @@
     "tailwindcss": "^3.0.24",
     "ts-node": "^10.8.0",
     "typescript": "^4.6.4",
-    "vite-tsconfig-paths": "^3.4.1",
-    "vitest": "^0.12.9"
+    "vite-tsconfig-paths": "^3.5.0",
+    "vitest": "^0.23.2"
   },
   "engines": {
     "node": ">=14"

--- a/remix.config.js
+++ b/remix.config.js
@@ -16,7 +16,9 @@ module.exports = {
       if (process.env.NODE_ENV === "production") return;
 
       console.log("⚠️ Test routes enabled.");
-      route("__tests/delete-user", path.join(__dirname, "test/test-routes/delete-user.ts"));
+
+      const appDir = path.join(__dirname, "app");
+      route("__tests/delete-user", path.relative(appDir, "test/test-routes/delete-user.ts"));
     });
   },
 };

--- a/test/setup-test-env.ts
+++ b/test/setup-test-env.ts
@@ -1,4 +1,4 @@
-import { installGlobals } from "@remix-run/node/globals";
+import { installGlobals } from "@remix-run/node";
 import "@testing-library/jest-dom/extend-expect";
 
 installGlobals();


### PR DESCRIPTION
Closes #9 

Looks like the path to the file wasn't being resolved correctly. I suspect `route` internals changed to resolve relative to `app`. This is the same method used in the [grunge-stack test routes](https://github.com/remix-run/grunge-stack/blob/977710c74584f42f06dc5e4abca5511dcec9e70b/remix.config.js#L24)
